### PR TITLE
Fix IndexSizeError on Firefox, in drawPart

### DIFF
--- a/codef/codef_core.js
+++ b/codef/codef_core.js
@@ -334,11 +334,19 @@ function canvas(w, h, divname){
         		x-=partx/(this.midhandled==true?2:1);
         		partw+=partx;
         		partx=0;
+            } else {
+                if (this.midhandled==false) {
+                    partw = Math.min(partw,this.img.width-partx);
+                }
         	}
         	if(party<0) {
         		y-=party/(this.midhandled==true?2:1);
         		parth+=party;
         		party=0;
+            } else {
+                if (this.midhandled==false) {
+                    parth = Math.min(parth,this.img.height-party);
+                }
         	}
         	if(partw<=0 || parth<=0){
         		return;

--- a/codef/codef_core.js
+++ b/codef/codef_core.js
@@ -551,11 +551,19 @@ function image(img){
         		x-=partx/(this.midhandled==true?2:1);
         		partw+=partx;
         		partx=0;
+            } else {
+                if (this.midhandled==false) {
+                    partw = Math.min(partw,this.img.width-partx);
+                }
         	}
         	if(party<0) {
         		y-=party/(this.midhandled==true?2:1);
         		parth+=party;
         		party=0;
+            } else {
+                if (this.midhandled==false) {
+                    parth = Math.min(parth,this.img.height-party);
+                }
         	}
         	if(partw<=0 || parth<=0){
         		return;

--- a/codef/codef_core.js
+++ b/codef/codef_core.js
@@ -330,6 +330,16 @@ function canvas(w, h, divname){
 		mycanvas.drawTile(mycanvas,10,10,0,0,50,50,1,0,1,1);
         */
         this.drawPart = function(dst,x,y,partx,party,partw,parth,alpha, rot,zx,zy){
+        	if(partx<0) {
+        		x-=partx/(this.midhandled==true?2:1);
+        		partw+=partx;
+        		partx=0;
+        	}
+        	if(party<0) {
+        		y-=party/(this.midhandled==true?2:1);
+        		parth+=party;
+        		party=0;
+        	}
         	if(partw<=0 || parth<=0){
         		return;
         	}
@@ -537,6 +547,19 @@ function image(img){
 		myimage.drawTile(mycanvas,10,10,0,0,50,50,1,0,1,1);
         */
         this.drawPart = function(dst,x,y,partx,party,partw,parth,alpha, rot,zx,zy){
+        	if(partx<0) {
+        		x-=partx/(this.midhandled==true?2:1);
+        		partw+=partx;
+        		partx=0;
+        	}
+        	if(party<0) {
+        		y-=party/(this.midhandled==true?2:1);
+        		parth+=party;
+        		party=0;
+        	}
+        	if(partw<=0 || parth<=0){
+        		return;
+        	}
                 var tmp=dst.contex.globalAlpha;
 		if(typeof(alpha)=='undefined') alpha=1;
                 dst.contex.globalAlpha=alpha;


### PR DESCRIPTION
Fix an error in Firefox :

> IndexSizeError: Index or size is negative or greater than the allowed amount

when partx or party are negative.

Input parameters are automatically clipped so that the function draws only what is necessary
